### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/binoptimisation.py
+++ b/binoptimisation.py
@@ -75,7 +75,7 @@ def draw_ROC(var ='dipho_dijet_MVA',
     ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
     for proc in ordsam:
         tree  = heppi.samples[proc].get('_root_tree_')#roof.Get(treename.replace('*',proc))
-        histstr = '(%i,%f,%f)' %(int(400),-1, 1)
+        histstr = '({0:d},{1:f},{2:f})'.format(int(400), -1, 1)
         if proc == 'Data':
             cutflow = cutflow.replace('weight*','').replace('weight','')
             
@@ -182,7 +182,7 @@ def GetBondaryBin(var    = 'dijet_BDT',
     hsig.SetTitle(";" + heppi.variables[var]['title']+";entries")
     # === cutflow
     if len(cutflow)!=0 :
-        cutflow = 'weight*(' + cutflow + ('&& %s > %f' % (var, xmin)) + ('&& %s < %f' % (var, xmax)) + ')'
+        cutflow = 'weight*(' + cutflow + ('&& {0!s} > {1:f}'.format(var, xmin)) + ('&& {0!s} < {1:f}'.format(var, xmax)) + ')'
     else:
         cutflow = 'weight'
         
@@ -190,7 +190,7 @@ def GetBondaryBin(var    = 'dijet_BDT',
     ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
     for proc in ordsam:
         tree  = heppi.samples[proc].get('_root_tree_')#roof.Get(treename.replace('*',proc))
-        histstr = '(%i,%f,%f)' %(int(nbin),-1, 1)
+        histstr = '({0:d},{1:f},{2:f})'.format(int(nbin), -1, 1)
         tree.Project(
             'h_'+var + histstr,
             var,
@@ -218,11 +218,11 @@ def GetBondaryBin(var    = 'dijet_BDT',
     catcut = []
     
     if len(cutflow)!=0 :
-        cutflow = 'weight*(' + cutflow + ('&& %s > %f' % (var, xmin)) + ('&& %s < %f' % (var, xmax)) + ')'
+        cutflow = 'weight*(' + cutflow + ('&& {0!s} > {1:f}'.format(var, xmin)) + ('&& {0!s} < {1:f}'.format(var, xmax)) + ')'
     else:
         cutflow = 'weight'
 
-    bar    = ProgressBar(widgets=[colored('-- variables:: %20s   ' % variable, 'green'),
+    bar    = ProgressBar(widgets=[colored('-- variables:: {0:20!s}   '.format(variable), 'green'),
                                   Percentage(),'  ' ,Bar('>'), ' ', ETA()], term_width=100)
     for ibin in bar(range(0, hsig.GetNbinsX()+1)):
         Z  = 0
@@ -256,7 +256,7 @@ def GetBondaryBin(var    = 'dijet_BDT',
     line.DrawLine(catvalue[0],0,catvalue[0],catvalue[1])
     
     print 'category (',catidx,') boundary [',catvalue[0],'][',catvalue[1],']'
-    draw_labels(('Category VBF-%i' % catidx)+ ' \\BDT > '+('%1.3f'%catvalue[0]))
+    draw_labels(('Category VBF-{0:d}'.format(catidx))+ ' \\BDT > '+('{0:1.3f}'.format(catvalue[0])))
     c.SaveAs('plots/fom_cat'+ str(catidx) + '.pdf')
     c.SaveAs('plots/fom_cat'+ str(catidx) + '.png')
     return catvalue
@@ -313,7 +313,7 @@ def GetCategoryBounds(var    = 'dijet_BDT',
     ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
     for proc in ordsam:
         tree  = heppi.samples[proc].get('_root_tree_')#roof.Get(treename.replace('*',proc))
-        histstr = '(%i,%f,%f)' %(int(nbin),-1, 1)
+        histstr = '({0:d},{1:f},{2:f})'.format(int(nbin), -1, 1)
         tree.Project(
             'h_'+var + histstr,
             var,
@@ -377,8 +377,8 @@ def GetCategoryBounds(var    = 'dijet_BDT',
     
     print 'bounds == [',opt_bounds[0], ']'
     #draw_labels(('Category VBF-%i' % catidx)+ ' \\BDT > '+('%1.3f'%catvalue[0]))
-    c.SaveAs('plots/fom_cat_bounds_scan_smooth_%i.pdf' % smooth_index)
-    c.SaveAs('plots/fom_cat_bounds_scan_smooth_%i.png' % smooth_index)
+    c.SaveAs('plots/fom_cat_bounds_scan_smooth_{0:d}.pdf'.format(smooth_index))
+    c.SaveAs('plots/fom_cat_bounds_scan_smooth_{0:d}.png'.format(smooth_index))
     
     c2 = ROOT.TCanvas('c2_boundary_optimisation','MVA',1200,600)
     c2.Divide(2,1)
@@ -399,8 +399,8 @@ def GetCategoryBounds(var    = 'dijet_BDT',
     h_roc_bkg.Draw('colz')
     
     raw_input('.......')
-    c2.SaveAs('plots/fom_cdt_bounds_scan_smooth_%i.pdf' % smooth_index)
-    c2.SaveAs('plots/fom_cdt_bounds_scan_smooth_%i.png' % smooth_index)
+    c2.SaveAs('plots/fom_cdt_bounds_scan_smooth_{0:d}.pdf'.format(smooth_index))
+    c2.SaveAs('plots/fom_cdt_bounds_scan_smooth_{0:d}.png'.format(smooth_index))
     
     return opt_bounds
 
@@ -450,7 +450,7 @@ def GetCategoryPDFBounds(var    = 'dijet_BDT',
     ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
     for proc in ordsam:
         tree  = heppi.samples[proc].get('_root_tree_')#roof.Get(treename.replace('*',proc))
-        histstr = '(%i,%f,%f)' %(int(nbin),-1, 1)
+        histstr = '({0:d},{1:f},{2:f})'.format(int(nbin), -1, 1)
         tree.Project(
             'h_'+var + histstr,
             var,
@@ -548,24 +548,24 @@ def print_categories(var, categories = None, select=''):
 
         # === cutflow
         logger.info('\hline')
-        logger.info('category( %i ) &%12.3f &&\\' % (categories.index(cat),cat))
+        logger.info('category( {0:d} ) &{1:12.3f} &&\\'.format(categories.index(cat), cat))
         logger.info('\hline')
-        logger.info('%12s &%12s &%12s &%12s \\' % ('process', 'total event', 'selection', 'efficiency'))
+        logger.info('{0:12!s} &{1:12!s} &{2:12!s} &{3:12!s} \\'.format('process', 'total event', 'selection', 'efficiency'))
         ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
         for proc in ordsam:
             tree  = heppi.samples[proc].get('_root_tree_')
             cutflow_sel = ''
             cutflow_all = ''
             if len(cutflow)!=0 :
-                cutflow_sel = 'weight*(' + cutflow + ('&& %s > %f' % (var, cat)) +')'
+                cutflow_sel = 'weight*(' + cutflow + ('&& {0!s} > {1:f}'.format(var, cat)) +')'
                 cutflow_all = 'weight*(' + cutflow + ')'
             else:
-                cutflow_sel = 'weight*(' + ('%s > %f' % (var, cat)) +')'
+                cutflow_sel = 'weight*(' + ('{0!s} > {1:f}'.format(var, cat)) +')'
                 cutflow_all = 'weight'
 
             if 'Data' != proc:
-                cutflow_all = cutflow_all.replace('weight','weight*%f' % (heppi.treeinfo.get('kfactor',1.0)))
-                cutflow_sel = cutflow_sel.replace('weight','weight*%f' % (heppi.treeinfo.get('kfactor',1.0)))
+                cutflow_all = cutflow_all.replace('weight','weight*{0:f}'.format((heppi.treeinfo.get('kfactor',1.0))))
+                cutflow_sel = cutflow_sel.replace('weight','weight*{0:f}'.format((heppi.treeinfo.get('kfactor',1.0))))
             else:
                 cutflow_all = cutflow_all.replace('weight*','')
                 cutflow_sel = cutflow_sel.replace('weight*','')
@@ -582,7 +582,7 @@ def print_categories(var, categories = None, select=''):
             )
             h_sel = ROOT.gDirectory.Get('h_sel_entries_'+proc)
             h_all = ROOT.gDirectory.Get('h_all_entries_'+proc)
-            logger.info('%12s &%12.3f &%12.3f &%12.3f \\' % (proc,h_all.Integral(),
+            logger.info('{0:12!s} &{1:12.3f} &{2:12.3f} &{3:12.3f} \\'.format(proc, h_all.Integral(),
                                                            h_sel.Integral(),
                                                            100*float(h_sel.Integral())/float(h_all.Integral())))
             if heppi.samples[proc]['label']== 'background':
@@ -597,17 +597,17 @@ def print_categories(var, categories = None, select=''):
                 
         # -------------------------------------------------------------------
         logger.info('\hline')
-        logger.info('%12s &%12.3f &%12.3f &%12.3f \\' % ('BKG ',
+        logger.info('{0:12!s} &{1:12.3f} &{2:12.3f} &{3:12.3f} \\'.format('BKG ',
                                                          hbkg_all.Integral(),
                                                          hbkg_sel.Integral(),
                                                          100*float(hbkg_sel.Integral())/float(hbkg_all.Integral())))
-        logger.info('%12s &%12.3f &%12.3f &%12.3f \\' % ('SIG',
+        logger.info('{0:12!s} &{1:12.3f} &{2:12.3f} &{3:12.3f} \\'.format('SIG',
                                                          hsig_all.Integral(),
                                                          hsig_sel.Integral(),
                                                          100*float(hsig_sel.Integral())/float(hsig_all.Integral())))
         logger.info('\hline')
-        logger.info('S/\sqrt(S+B) = %12.3f' % (
-            float(hsig_sel.Integral())/math.sqrt(hsig_sel.Integral()+hbkg_sel.Integral()) ))
+        logger.info('S/\sqrt(S+B) = {0:12.3f}'.format((
+            float(hsig_sel.Integral())/math.sqrt(hsig_sel.Integral()+hbkg_sel.Integral()) )))
         logger.info('\hline')
 
 #class 2DimBoundaryOpt:

--- a/makeplotcard.py
+++ b/makeplotcard.py
@@ -33,7 +33,7 @@ def create_json(rootfile='file.root', treename='', jout=''):
     # create list of variables
     varlist={}
     for var in tree.GetListOfLeaves():
-        print ('variable: %25s' % var.GetTitle())
+        print ('variable: {0:25!s}'.format(var.GetTitle()))
         varlist[var.GetTitle()]={'title':'','hist':'(100,0,100)','norm':False,'log':False, 'cut':''}
         # create a json file
     samples     = json.loads(open('config/samples.json').read())

--- a/travis_pypi_setup.py
+++ b/travis_pypi_setup.py
@@ -114,7 +114,7 @@ if '__main__' == __name__:
     import argparse
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--repo', default=GITHUB_REPO,
-                        help='GitHub repo (default: %s)' % GITHUB_REPO)
+                        help='GitHub repo (default: {0!s})'.format(GITHUB_REPO))
     parser.add_argument('--password',
                         help='PyPI password (will prompt if not provided)')
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:yhaddad:Heppi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:yhaddad:Heppi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
