### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/heppi/__init__.py
+++ b/heppi/__init__.py
@@ -7,6 +7,6 @@ __email__   = 'yhaddad@cern.ch'
 __version__ = '2.1.0'
 
 heppi.logger.info("")
-heppi.logger.info("Heppi %5s -- Developed by %s (%s)" % (__version__, __author__, __email__))
-heppi.logger.info("%14s Copyright (C) 2015-2016 Imperial College London" % "")
+heppi.logger.info("Heppi {0:5!s} -- Developed by {1!s} ({2!s})".format(__version__, __author__, __email__))
+heppi.logger.info("{0:14!s} Copyright (C) 2015-2016 Imperial College London".format(""))
 heppi.logger.info("")

--- a/heppi/heppi.py
+++ b/heppi/heppi.py
@@ -49,7 +49,7 @@ class utils:
             0.32112 --> 0.32
         """
         if num != 1:
-            s = ('%g'% (num)).rstrip('0').rstrip('.')
+            s = ('{0:g}'.format((num))).rstrip('0').rstrip('.')
         else :
             s = ('' if unit else '1')
         return s
@@ -179,7 +179,7 @@ class variable(object):
         if type(self.hist) == type([]) or type(self.hist) == type(()):
             self.nbin  = self.hist[0]
             self.range = self.hist[1:]
-            self.hist = '(%s)' % (', '.join(map(str, self.hist)))
+            self.hist = '({0!s})'.format((', '.join(map(str, self.hist))))
         else:
             self.range = re.findall("[-+]?\d+[\.]?\d*",self.hist)
             self.nbin  = int(self.range[0])
@@ -193,7 +193,7 @@ class variable(object):
         self.root_stack   = None
         self.root_cutflow = ''
     def __str__(self):
-        return " -- variable :: %20s %18s %12s" % (self.name, self.hist, self.unit)
+        return " -- variable :: {0:20!s} {1:18!s} {2:12!s}".format(self.name, self.hist, self.unit)
 class systematic(object):
     """
     object type containing Heppi options:
@@ -292,7 +292,7 @@ class sample  (object):
             self.systematics[syst].up_root_tree   = tree_up
             self.systematics[syst].down_root_tree = tree_dw
     def __str__(self):
-        return " -- sample :: %20s %12i" % (self.name, self.root_tree.GetEntries())
+        return " -- sample :: {0:20!s} {1:12d}".format(self.name, self.root_tree.GetEntries())
 class options (object):
     """
     object type containing Heppi options:
@@ -319,7 +319,7 @@ class options (object):
     def __str__(self):
         string = " -- Heppi options :\n"
         for opt in self.__dict__:
-             string += "    + %15s : %20s \n" % ( opt , str(self.__dict__[opt]))
+             string += "    + {0:15!s} : {1:20!s} \n".format(opt , str(self.__dict__[opt]))
         return string
 class scatter_opt(object):
     """
@@ -340,7 +340,7 @@ class scatter_opt(object):
     def __str__(self):
         string = " -- Heppi scatter plots :\n"
         for opt in self.__dict__:
-             string += "  -- %15s : %20s \n" % ( opt , str(self.__dict__[opt]))
+             string += "  -- {0:15!s} : {1:20!s} \n".format(opt , str(self.__dict__[opt]))
         return string
 
 class instack ():
@@ -368,7 +368,7 @@ class instack ():
             _config_ = json.loads(jsmin(f.read()),object_pairs_hook=OrderedDict)
         if self.cutcard != '':
             logger.info(' ---- cut card is specified ----')
-            logger.info(' -- %20s ' % ( self.cutcard )    )
+            logger.info(' -- {0:20!s} '.format(( self.cutcard ))    )
             with open(self.cutcard) as f:
                 _cuts_   = json.loads(jsmin(f.read()))
                 _config_ = merge(config, cuts)
@@ -425,7 +425,7 @@ class instack ():
                         _tre_ = sam.split(':')[1]
                     for f in glob.glob( self.sampledir + '/*'+ _sam_ +'*.root'):
                         chain.Add( f + '/' + _tre_ )
-                        logger.debug("[a][%s] = [%s/%s]" % ( sample.name, f , _tre_ ) )
+                        logger.debug("[a][{0!s}] = [{1!s}/{2!s}]".format(sample.name, f , _tre_ ) )
                 # preliminary systematics handling
                 if 'background' in sample.label.lower()  :
                     for systkey, syst in self.systematics.items() :
@@ -449,7 +449,7 @@ class instack ():
                     _tre_ = sam.split(':')[1]
                 for f in glob.glob( self.sampledir + '/*'+ _sam_ +'*.root'):
                     chain.Add( f + '/' + _tre_ )
-                    logger.debug("[b][%s] = [%s/%s]" % ( sample.name, f , _tre_ ) )
+                    logger.debug("[b][{0!s}] = [{1!s}/{2!s}]".format(sample.name, f , _tre_ ) )
                 if 'background' in sample.label.lower()  :
                     for systkey, syst in self.systematics.items() :
                         _ch_ = {}
@@ -870,7 +870,7 @@ class instack ():
         else:
             variable.root_cutflow = self.options.weight_branch
 
-        bar = ProgressBar(widgets=[colored(' -- variable :: %20s   ' % ((variable.name[:18] + '..') if len(variable.name)>20 else variable.name), 'green'),
+        bar = ProgressBar(widgets=[colored(' -- variable :: {0:20!s}   '.format(((variable.name[:18] + '..') if len(variable.name)>20 else variable.name)), 'green'),
                           Percentage(),'  ' ,Bar('>'), ' ', ETA()], term_width=100)
         for proc,sample in bar(self.samples.items()):
             _cutflow_ = variable.root_cutflow
@@ -884,9 +884,9 @@ class instack ():
                     variable.formula,
                     '*'.join(
                         [   _cutflow_,
-                            "%f" % self.options.kfactor,
-                            "%f" % self.options.intlumi,
-                            "%f" % sample.kfactor
+                            "{0:f}".format(self.options.kfactor),
+                            "{0:f}".format(self.options.intlumi),
+                            "{0:f}".format(sample.kfactor)
                         ]
                     )
                 )
@@ -898,7 +898,7 @@ class instack ():
                 )
 
             else:
-                logger.error(' -- the label of the sample "%s" is not recognised by Heepi' % sample.name )
+                logger.error(' -- the label of the sample "{0!s}" is not recognised by Heepi'.format(sample.name) )
                 return
 
             hist = ROOT.gDirectory.Get('h_' + variable.name )
@@ -907,7 +907,7 @@ class instack ():
             if variable.norm and hist.Integral()!=0:
                 hist.Sumw2()
                 hist.Scale(1.0/hist.Integral())
-            if hist.Integral() == 0 : logger.warning(' The Integral of the histogram is null, please check this variable: %s' % varkey)
+            if hist.Integral() == 0 : logger.warning(' The Integral of the histogram is null, please check this variable: {0!s}'.format(varkey))
             if 'background' in sample.label.lower():
                 for key,syst in sample.systematics.items() :
                     for _sys_flip_ in ['up','down']:
@@ -916,9 +916,9 @@ class instack ():
                             variable.formula,
                             '*'.join(
                                 [   _cutflow_,
-                                    "%f" % self.options.kfactor,
-                                    "%f" % self.options.intlumi,
-                                    "%f" % sample.kfactor
+                                    "{0:f}".format(self.options.kfactor),
+                                    "{0:f}".format(self.options.intlumi),
+                                    "{0:f}".format(sample.kfactor)
                                 ]
                             )
                         )
@@ -939,7 +939,7 @@ class instack ():
                 variable.root_histos.append(hist)
                 if sample.kfactor != 1:
                     variable.root_legend.AddEntry(hist,
-                                    sample.title + ("#times%i" % sample.kfactor ),
+                                    sample.title + ("#times{0:d}".format(sample.kfactor) ),
                                     "l" );
                 else:
                     variable.root_legend.AddEntry( hist, sample.title, "l" );
@@ -969,7 +969,7 @@ class instack ():
         ROOT.SetOwnership(_htmp_,0)
         bounds = [float(s) for s in re.findall('[-+]?\d*\.\d+|\d+',variable.hist )]
         _htmp_.SetTitle(';' + variable.title
-                       + (';events / %s %s '% (utils.fformat((bounds[2]-bounds[1])/bounds[0], variable.unit != ""),
+                       + (';events / {0!s} {1!s} '.format(utils.fformat((bounds[2]-bounds[1])/bounds[0], variable.unit != ""),
                                                variable.unit) ))
         _htmp_.Reset()
         _ymax_ = max([x.GetMaximum() for x in variable.root_histos])
@@ -1028,7 +1028,7 @@ class instack ():
         # if (self.systematics.keys())>0 : self.options.label.append('+'.join(self.systematics.keys()))
         utils.draw_labels(self.options.label)
         # if (self.systematics.keys())>0 : self.options.label.pop()
-        utils.draw_cms_headlabel( label_right='#sqrt{s} = 13 TeV, L = %1.2f fb^{-1}' % self.options.intlumi )
+        utils.draw_cms_headlabel( label_right='#sqrt{{s}} = 13 TeV, L = {0:1.2f} fb^{{-1}}'.format(self.options.intlumi) )
         #
         c.cd()
         c.cd(2)
@@ -1126,8 +1126,8 @@ class instack ():
                 variable.formula,
                 '*'.join(
                     [   '(' + _cutflow_ + ')',
-                        "%f" % self.options.kfactor,
-                        "%f" % self.options.intlumi,
+                        "{0:f}".format(self.options.kfactor),
+                        "{0:f}".format(self.options.intlumi),
                         self.options.weight_branch
                     ]
                 )
@@ -1142,9 +1142,9 @@ class instack ():
         try:
             variable = self.variables[varkey]
         except KeyError:
-            logger.error(colored('ERROR: Variable (%s) not defined !!'% varkey ,'red'))
+            logger.error(colored('ERROR: Variable ({0!s}) not defined !!'.format(varkey) ,'red'))
             return
-        selection = "(%s)&&(%s)" % (allsel, selection)
+        selection = "({0!s})&&({1!s})".format(allsel, selection)
         hsel = self.histogram(variable, type=sample, label = 'sel_' + label, cut=selection)
         htot = self.histogram(variable, type=sample, label = 'all_' + label, cut=allsel   )
         _gr_ = ROOT.TGraphAsymmErrors(hsel,htot)
@@ -1156,7 +1156,7 @@ class instack ():
             try:
                 variable = self.variables[varkey]
             except KeyError:
-                logger.error(colored('ERROR: Variable (%s) not defined !!'% varkey ,'red'))
+                logger.error(colored('ERROR: Variable ({0!s}) not defined !!'.format(varkey) ,'red'))
                 return
 
             _h_ = self.histogram(variable, type=sample, label = label, cut=selection)
@@ -1173,7 +1173,7 @@ class instack ():
         try:
             variable = self.variables[varkey]
         except KeyError:
-            logger.error(colored('ERROR: Variable (%s) not defined !!'% varkey ,'red'))
+            logger.error(colored('ERROR: Variable ({0!s}) not defined !!'.format(varkey) ,'red'))
             return
         histname = ('roc_' + variable.name + '_' + label + '_')
         _cutflow_ = self.variable_cutflow(variable.name,'')
@@ -1184,8 +1184,8 @@ class instack ():
             variable.formula,
             '*'.join(
                 [   "(" + _cutflow_ + ")",
-                    "%f" % self.options.kfactor,
-                    "%f" % self.options.intlumi,
+                    "{0:f}".format(self.options.kfactor),
+                    "{0:f}".format(self.options.intlumi),
                     self.options.weight_branch
                 ]
             )
@@ -1199,8 +1199,8 @@ class instack ():
             variable.formula,
             '*'.join(
                 [   "(" + _cutflow2_ + ")",
-                    "%f" % self.options.kfactor,
-                    "%f" % self.options.intlumi,
+                    "{0:f}".format(self.options.kfactor),
+                    "{0:f}".format(self.options.intlumi),
                     self.options.weight_branch
                 ]
             )
@@ -1283,8 +1283,8 @@ class instack ():
                           variable_y.formula +":"+variable_x.formula,
                           '*'.join(
                                 [   "(" + _cutflow_here_ + ")",
-                                    "%f" % self.options.kfactor,
-                                    "%f" % self.options.intlumi,
+                                    "{0:f}".format(self.options.kfactor),
+                                    "{0:f}".format(self.options.intlumi),
                                     _weight_
                                 ]
                             )
@@ -1296,8 +1296,8 @@ class instack ():
                 print '::', self.options.weight_branch if 'data' not in sample.label.lower() else '1'
                 print '::', '*'.join(
                       [   "("+ _cutflow_here_+")",
-                          "%f" % self.options.kfactor,
-                          "%f" % self.options.intlumi,
+                          "{0:f}".format(self.options.kfactor),
+                          "{0:f}".format(self.options.intlumi),
                           self.options.weight_branch if 'data' not in sample.label.lower() else '1'
                       ]
                   )
@@ -1363,7 +1363,7 @@ class instack ():
 
         if make_profiles:
             _yaxistitle_ = '#LT' + variable_y.title + '#GT'
-        scatter_bkg.SetTitle(';%s %s;%s %s' % (variable_x.title, xunit, _yaxistitle_, yunit) )
+        scatter_bkg.SetTitle(';{0!s} {1!s};{2!s} {3!s}'.format(variable_x.title, xunit, _yaxistitle_, yunit) )
         scatter_bkg.GetXaxis().SetTitleOffset(0.01)
         scatter_bkg.GetYaxis().SetTitleOffset(0.01)
         scatter_sig.GetXaxis().SetTitleOffset(0.01)
@@ -1404,7 +1404,7 @@ class instack ():
 
 
         utils.draw_labels( self.options.label)
-        utils.scatter_cms_headlabel( label_right='#sqrt{s} = 13 TeV, L = %1.2f fb^{-1}' % self.options.intlumi )
+        utils.scatter_cms_headlabel( label_right='#sqrt{{s}} = 13 TeV, L = {0:1.2f} fb^{{-1}}'.format(self.options.intlumi) )
 
         utils.draw_cut_line(scatter_sig,variable_x, axis='x')
         utils.draw_cut_line(scatter_sig,variable_y, axis='y')

--- a/macros/binoptimisation.py
+++ b/macros/binoptimisation.py
@@ -71,7 +71,7 @@ def draw_ROC(var ='dipho_dijet_MVA',
     ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
     for proc in ordsam:
         tree  = heppi.samples[proc].get('_root_tree_')#roof.Get(treename.replace('*',proc))
-        histstr = '(%i,%f,%f)' %(int(400),-1, 1)
+        histstr = '({0:d},{1:f},{2:f})'.format(int(400), -1, 1)
         if proc == 'Data':
             cutflow = cutflow.replace('weight*','').replace('weight','')
             
@@ -178,7 +178,7 @@ def GetBondaryBin(var    = 'dijet_BDT',
     hsig.SetTitle(";" + heppi.variables[var]['title']+";entries")
     # === cutflow
     if len(cutflow)!=0 :
-        cutflow = 'weight*(' + cutflow + ('&& %s > %f' % (var, xmin)) + ('&& %s < %f' % (var, xmax)) + ')'
+        cutflow = 'weight*(' + cutflow + ('&& {0!s} > {1:f}'.format(var, xmin)) + ('&& {0!s} < {1:f}'.format(var, xmax)) + ')'
     else:
         cutflow = 'weight'
         
@@ -186,7 +186,7 @@ def GetBondaryBin(var    = 'dijet_BDT',
     ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
     for proc in ordsam:
         tree  = heppi.samples[proc].get('_root_tree_')#roof.Get(treename.replace('*',proc))
-        histstr = '(%i,%f,%f)' %(int(nbin),-1, 1)
+        histstr = '({0:d},{1:f},{2:f})'.format(int(nbin), -1, 1)
         tree.Project(
             'h_'+var + histstr,
             var,
@@ -214,11 +214,11 @@ def GetBondaryBin(var    = 'dijet_BDT',
     catcut = []
     
     if len(cutflow)!=0 :
-        cutflow = 'weight*(' + cutflow + ('&& %s > %f' % (var, xmin)) + ('&& %s < %f' % (var, xmax)) + ')'
+        cutflow = 'weight*(' + cutflow + ('&& {0!s} > {1:f}'.format(var, xmin)) + ('&& {0!s} < {1:f}'.format(var, xmax)) + ')'
     else:
         cutflow = 'weight'
 
-    bar    = ProgressBar(widgets=[colored('-- variables:: %20s   ' % variable, 'green'),
+    bar    = ProgressBar(widgets=[colored('-- variables:: {0:20!s}   '.format(variable), 'green'),
                                   Percentage(),'  ' ,Bar('>'), ' ', ETA()], term_width=100)
     for ibin in bar(range(0, hsig.GetNbinsX()+1)):
         Z  = 0
@@ -252,7 +252,7 @@ def GetBondaryBin(var    = 'dijet_BDT',
     line.DrawLine(catvalue[0],0,catvalue[0],catvalue[1])
     
     print 'category (',catidx,') boundary [',catvalue[0],'][',catvalue[1],']'
-    draw_labels(('Category VBF-%i' % catidx)+ ' \\BDT > '+('%1.3f'%catvalue[0]))
+    draw_labels(('Category VBF-{0:d}'.format(catidx))+ ' \\BDT > '+('{0:1.3f}'.format(catvalue[0])))
     c.SaveAs('plots/fom_cat'+ str(catidx) + '.pdf')
     c.SaveAs('plots/fom_cat'+ str(catidx) + '.png')
     return catvalue
@@ -307,7 +307,7 @@ def GetCategoryBounds(var    = 'dijet_BDT',
     ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
     for proc in ordsam:
         tree  = heppi.samples[proc].get('_root_tree_')#roof.Get(treename.replace('*',proc))
-        histstr = '(%i,%f,%f)' %(int(nbin),-1, 1)
+        histstr = '({0:d},{1:f},{2:f})'.format(int(nbin), -1, 1)
         tree.Project(
             'h_'+var + histstr,
             var,
@@ -371,8 +371,8 @@ def GetCategoryBounds(var    = 'dijet_BDT',
     
     print 'bounds == [',opt_bounds[0], ']'
     #draw_labels(('Category VBF-%i' % catidx)+ ' \\BDT > '+('%1.3f'%catvalue[0]))
-    c.SaveAs('plots/fom_cat_bounds_scan_smooth_%i.pdf' % smooth_index)
-    c.SaveAs('plots/fom_cat_bounds_scan_smooth_%i.png' % smooth_index)
+    c.SaveAs('plots/fom_cat_bounds_scan_smooth_{0:d}.pdf'.format(smooth_index))
+    c.SaveAs('plots/fom_cat_bounds_scan_smooth_{0:d}.png'.format(smooth_index))
     
     c2 = ROOT.TCanvas('c2_boundary_optimisation','MVA',1200,600)
     c2.Divide(2,1)
@@ -393,8 +393,8 @@ def GetCategoryBounds(var    = 'dijet_BDT',
     h_roc_bkg.Draw('colz')
     
     raw_input('.......')
-    c2.SaveAs('plots/fom_cdt_bounds_scan_smooth_%i.pdf' % smooth_index)
-    c2.SaveAs('plots/fom_cdt_bounds_scan_smooth_%i.png' % smooth_index)
+    c2.SaveAs('plots/fom_cdt_bounds_scan_smooth_{0:d}.pdf'.format(smooth_index))
+    c2.SaveAs('plots/fom_cdt_bounds_scan_smooth_{0:d}.png'.format(smooth_index))
     
     return opt_bounds
 
@@ -442,7 +442,7 @@ def GetCategoryPDFBounds(var    = 'dijet_BDT',
     ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
     for proc in ordsam:
         tree  = heppi.samples[proc].get('_root_tree_')#roof.Get(treename.replace('*',proc))
-        histstr = '(%i,%f,%f)' %(int(nbin),-1, 1)
+        histstr = '({0:d},{1:f},{2:f})'.format(int(nbin), -1, 1)
         tree.Project(
             'h_'+var + histstr,
             var,
@@ -538,24 +538,24 @@ def print_categories(var, categories = [], select=''):
 
         # === cutflow
         logger.info('\hline')
-        logger.info('category( %i ) &%12.3f &&\\' % (categories.index(cat),cat))
+        logger.info('category( {0:d} ) &{1:12.3f} &&\\'.format(categories.index(cat), cat))
         logger.info('\hline')
-        logger.info('%12s &%12s &%12s &%12s \\' % ('process', 'total event', 'selection', 'efficiency'))
+        logger.info('{0:12!s} &{1:12!s} &{2:12!s} &{3:12!s} \\'.format('process', 'total event', 'selection', 'efficiency'))
         ordsam = OrderedDict(sorted(heppi.samples.items(), key=lambda x: x[1]['order']))
         for proc in ordsam:
             tree  = heppi.samples[proc].get('_root_tree_')
             cutflow_sel = ''
             cutflow_all = ''
             if len(cutflow)!=0 :
-                cutflow_sel = 'weight*(' + cutflow + ('&& %s > %f' % (var, cat)) +')'
+                cutflow_sel = 'weight*(' + cutflow + ('&& {0!s} > {1:f}'.format(var, cat)) +')'
                 cutflow_all = 'weight*(' + cutflow + ')'
             else:
-                cutflow_sel = 'weight*(' + ('%s > %f' % (var, cat)) +')'
+                cutflow_sel = 'weight*(' + ('{0!s} > {1:f}'.format(var, cat)) +')'
                 cutflow_all = 'weight'
 
             if 'Data' != proc:
-                cutflow_all = cutflow_all.replace('weight','weight*%f' % (heppi.treeinfo.get('kfactor',1.0)))
-                cutflow_sel = cutflow_sel.replace('weight','weight*%f' % (heppi.treeinfo.get('kfactor',1.0)))
+                cutflow_all = cutflow_all.replace('weight','weight*{0:f}'.format((heppi.treeinfo.get('kfactor',1.0))))
+                cutflow_sel = cutflow_sel.replace('weight','weight*{0:f}'.format((heppi.treeinfo.get('kfactor',1.0))))
             else:
                 cutflow_all = cutflow_all.replace('weight*','')
                 cutflow_sel = cutflow_sel.replace('weight*','')
@@ -572,7 +572,7 @@ def print_categories(var, categories = [], select=''):
             )
             h_sel = ROOT.gDirectory.Get('h_sel_entries_'+proc)
             h_all = ROOT.gDirectory.Get('h_all_entries_'+proc)
-            logger.info('%12s &%12.3f &%12.3f &%12.3f \\' % (proc,h_all.Integral(),
+            logger.info('{0:12!s} &{1:12.3f} &{2:12.3f} &{3:12.3f} \\'.format(proc, h_all.Integral(),
                                                            h_sel.Integral(),
                                                            100*float(h_sel.Integral())/float(h_all.Integral())))
             if heppi.samples[proc]['label']== 'background':
@@ -587,17 +587,17 @@ def print_categories(var, categories = [], select=''):
                 
         # -------------------------------------------------------------------
         logger.info('\hline')
-        logger.info('%12s &%12.3f &%12.3f &%12.3f \\' % ('BKG ',
+        logger.info('{0:12!s} &{1:12.3f} &{2:12.3f} &{3:12.3f} \\'.format('BKG ',
                                                          hbkg_all.Integral(),
                                                          hbkg_sel.Integral(),
                                                          100*float(hbkg_sel.Integral())/float(hbkg_all.Integral())))
-        logger.info('%12s &%12.3f &%12.3f &%12.3f \\' % ('SIG',
+        logger.info('{0:12!s} &{1:12.3f} &{2:12.3f} &{3:12.3f} \\'.format('SIG',
                                                          hsig_all.Integral(),
                                                          hsig_sel.Integral(),
                                                          100*float(hsig_sel.Integral())/float(hsig_all.Integral())))
         logger.info('\hline')
-        logger.info('S/\sqrt(S+B) = %12.3f' % (
-            float(hsig_sel.Integral())/math.sqrt(hsig_sel.Integral()+hbkg_sel.Integral()) ))
+        logger.info('S/\sqrt(S+B) = {0:12.3f}'.format((
+            float(hsig_sel.Integral())/math.sqrt(hsig_sel.Integral()+hbkg_sel.Integral()) )))
         logger.info('\hline')
 
 #class 2DimBoundaryOpt:

--- a/macros/makeplotcard.py
+++ b/macros/makeplotcard.py
@@ -41,13 +41,13 @@ def create_json(rootfile='file.root', treename='', jout=''):
             dim = [int(s) for s in re.findall('[-+]?\d*\.\d+|\d+', var.GetTitle().split('[')[1])]
 
             for idim in range(0, dim[0]):
-                _var_ = var.GetTitle().replace('[%i]'%dim[0], '[%i]'%idim)
+                _var_ = var.GetTitle().replace('[{0:d}]'.format(dim[0]), '[{0:d}]'.format(idim))
                 tree.Project("_h_"+_var_.split('[')[0],_var_)
                 _h_  = ROOT.gDirectory.Get('_h_' + _var_.split('[')[0])
                 nbin = _h_.GetNbinsX()
                 xmin = _h_.GetXaxis().GetXmin()
                 xmax = _h_.GetXaxis().GetXmax()
-                hist = "(%i,%1.3f,%1.3f)" % (nbin,xmin,xmax)
+                hist = "({0:d},{1:1.3f},{2:1.3f})".format(nbin, xmin, xmax)
                 varlist[_var_]={
                     'cut'  :'',
                     "hist" : hist,
@@ -55,9 +55,9 @@ def create_json(rootfile='file.root', treename='', jout=''):
                     "blind": "",
                     "log"  : True ,
                     "norm" : False,
-                    "title": var.GetTitle().replace('[%i]'%dim[0], '_%i'%idim)
+                    "title": var.GetTitle().replace('[{0:d}]'.format(dim[0]), '_{0:d}'.format(idim))
                 }
-                print ('variable: %25s' % var.GetTitle().replace('[%i]'%dim[0], '[%i]'%idim))
+                print ('variable: {0:25!s}'.format(var.GetTitle().replace('[{0:d}]'.format(dim[0]), '[{0:d}]'.format(idim))))
         else:
 
             tree.Project("_h_"+var.GetTitle(),var.GetTitle())
@@ -65,7 +65,7 @@ def create_json(rootfile='file.root', treename='', jout=''):
             nbin = _h_.GetNbinsX()
             xmin = _h_.GetXaxis().GetXmin()
             xmax = _h_.GetXaxis().GetXmax()
-            hist = "(%i,%1.3f,%1.3f)" % (nbin,xmin,xmax)
+            hist = "({0:d},{1:1.3f},{2:1.3f})".format(nbin, xmin, xmax)
             varlist[var.GetTitle()]={
                 'cut'  :'',
                 "hist" : hist,
@@ -75,7 +75,7 @@ def create_json(rootfile='file.root', treename='', jout=''):
                 "norm" : False,
                 "title": var.GetTitle()
             }
-            print ('variable: %25s' % var.GetTitle())
+            print ('variable: {0:25!s}'.format(var.GetTitle()))
         # create a json file
     # samples     = json.loads(open('samples.json').read())
     samples_new = {}

--- a/travis_pypi_setup.py
+++ b/travis_pypi_setup.py
@@ -114,7 +114,7 @@ if '__main__' == __name__:
     import argparse
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--repo', default=GITHUB_REPO,
-                        help='GitHub repo (default: %s)' % GITHUB_REPO)
+                        help='GitHub repo (default: {0!s})'.format(GITHUB_REPO))
     parser.add_argument('--password',
                         help='PyPI password (will prompt if not provided)')
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:yhaddad:Heppi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:yhaddad:Heppi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
